### PR TITLE
✅ [CRUD] espacios deprtivos terminado

### DIFF
--- a/app/routers/espacios.py
+++ b/app/routers/espacios.py
@@ -1,23 +1,88 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from app.database import get_db
 from app.models.espacio_deportivo import EspacioDeportivo
-from app.schemas.espacio_deportivo import EspacioDeportivoResponse, EspacioDeportivoCreate
+from app.schemas.espacio_deportivo import EspacioDeportivoResponse, EspacioDeportivoCreate, EspacioDeportivoUpdate
 
 router = APIRouter()
 
 @router.get("/", response_model=list[EspacioDeportivoResponse])
-def get_espacios(db: Session = Depends(get_db)):
-    return db.query(EspacioDeportivo).all()
+def get_espacios(include_inactive: bool = False, db: Session = Depends(get_db)):
+    """Obtener espacios deportivos, incluir inactivos solo si se solicita"""
+    query = db.query(EspacioDeportivo)
+    if not include_inactive:
+        query = query.filter(EspacioDeportivo.estado == "activo")
+    return query.all()
 
 @router.get("/{espacio_id}", response_model=EspacioDeportivoResponse)
 def get_espacio(espacio_id: int, db: Session = Depends(get_db)):
-    return db.query(EspacioDeportivo).filter(EspacioDeportivo.id_espacio_deportivo == espacio_id).first()
+    espacio = db.query(EspacioDeportivo).filter(EspacioDeportivo.id_espacio_deportivo == espacio_id).first()
+    if not espacio:
+        raise HTTPException(status_code=404, detail="Espacio deportivo no encontrado")
+    return espacio
 
 @router.post("/", response_model=EspacioDeportivoResponse)
 def create_espacio(espacio_data: EspacioDeportivoCreate, db: Session = Depends(get_db)):
+    # Verificar si ya existe un espacio con el mismo nombre
+    existing_espacio = db.query(EspacioDeportivo).filter(EspacioDeportivo.nombre == espacio_data.nombre).first()
+    if existing_espacio:
+        raise HTTPException(status_code=400, detail="Ya existe un espacio deportivo con ese nombre")
+    
     nuevo_espacio = EspacioDeportivo(**espacio_data.dict())
     db.add(nuevo_espacio)
     db.commit()
     db.refresh(nuevo_espacio)
     return nuevo_espacio
+
+@router.put("/{espacio_id}", response_model=EspacioDeportivoResponse)
+def update_espacio(espacio_id: int, espacio_data: EspacioDeportivoUpdate, db: Session = Depends(get_db)):
+    espacio = db.query(EspacioDeportivo).filter(EspacioDeportivo.id_espacio_deportivo == espacio_id).first()
+    if not espacio:
+        raise HTTPException(status_code=404, detail="Espacio deportivo no encontrado")
+    
+    # Verificar nombre único si se está actualizando
+    if espacio_data.nombre and espacio_data.nombre != espacio.nombre:
+        existing_espacio = db.query(EspacioDeportivo).filter(
+            EspacioDeportivo.nombre == espacio_data.nombre,
+            EspacioDeportivo.id_espacio_deportivo != espacio_id
+        ).first()
+        if existing_espacio:
+            raise HTTPException(status_code=400, detail="Ya existe un espacio deportivo con ese nombre")
+    
+    # Actualizar campos
+    for field, value in espacio_data.dict(exclude_unset=True).items():
+        setattr(espacio, field, value)
+    
+    db.commit()
+    db.refresh(espacio)
+    return espacio
+
+@router.delete("/{espacio_id}")
+def desactivar_espacio(espacio_id: int, db: Session = Depends(get_db)):
+    """Desactivar espacio deportivo (borrado lógico)"""
+    espacio = db.query(EspacioDeportivo).filter(EspacioDeportivo.id_espacio_deportivo == espacio_id).first()
+    if not espacio:
+        raise HTTPException(status_code=404, detail="Espacio deportivo no encontrado")
+    
+    if espacio.estado == "inactivo":
+        raise HTTPException(status_code=400, detail="El espacio deportivo ya está inactivo")
+    
+    espacio.estado = "inactivo"
+    db.commit()
+    
+    return {"detail": "Espacio deportivo desactivado exitosamente"}
+
+@router.put("/{espacio_id}/activar")
+def activar_espacio(espacio_id: int, db: Session = Depends(get_db)):
+    """Reactivar un espacio deportivo previamente desactivado"""
+    espacio = db.query(EspacioDeportivo).filter(EspacioDeportivo.id_espacio_deportivo == espacio_id).first()
+    if not espacio:
+        raise HTTPException(status_code=404, detail="Espacio deportivo no encontrado")
+    
+    if espacio.estado == "activo":
+        raise HTTPException(status_code=400, detail="El espacio deportivo ya está activo")
+    
+    espacio.estado = "activo"
+    db.commit()
+    
+    return {"detail": "Espacio deportivo activado exitosamente"}

--- a/app/schemas/espacio_deportivo.py
+++ b/app/schemas/espacio_deportivo.py
@@ -1,22 +1,22 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import Optional
 from datetime import datetime
 
 class EspacioDeportivoBase(BaseModel):
-    nombre: str
-    ubicacion: Optional[str] = None
-    capacidad: Optional[int] = None
-    estado: Optional[str] = "activo"
-    descripcion: Optional[str] = None
+   nombre: str = Field(..., min_length=1, max_length=100)
+   ubicacion: Optional[str] = Field(None, max_length=150)
+   capacidad: Optional[int] = Field(None, ge=1)
+   estado: Optional[str] = Field("activo", pattern="^(activo|inactivo)$")
+   descripcion: Optional[str] = None
 
 class EspacioDeportivoCreate(EspacioDeportivoBase):
     pass
 
 class EspacioDeportivoUpdate(BaseModel):
-    nombre: Optional[str] = None
-    ubicacion: Optional[str] = None
-    capacidad: Optional[int] = None
-    estado: Optional[str] = None
+    nombre: Optional[str] = Field(None, min_length=1, max_length=100)
+    ubicacion: Optional[str] = Field(None, max_length=150)
+    capacidad: Optional[int] = Field(None, ge=1)
+    estado: Optional[str] = Field(None, pattern="^(activo|inactivo)$")
     descripcion: Optional[str] = None
 
 class EspacioDeportivoResponse(EspacioDeportivoBase):


### PR DESCRIPTION
This pull request introduces significant improvements to the management of "espacios deportivos" (sports spaces) and "usuarios" (users) in the application. The main changes include implementing logical deletion (soft delete) and reactivation for both entities, enforcing uniqueness constraints, adding new endpoints for update and state management, and improving input validation with Pydantic. These enhancements make the API more robust, user-friendly, and consistent.

**Espacios Deportivos (Sports Spaces) Management:**
- Added logical deletion and reactivation endpoints for sports spaces, allowing them to be marked as inactive or active instead of being physically deleted.
- Implemented uniqueness check for the `nombre` field during creation and update to prevent duplicate sports space names.
- Improved the GET endpoint to allow filtering by active/inactive status using an `include_inactive` query parameter.
- Enhanced input validation for sports spaces using Pydantic's `Field`, including constraints on field length, allowed values, and required fields.

**Usuarios (Users) Management:**
- Switched from physical deletion to logical deletion (soft delete) for users, with new endpoints to deactivate and reactivate users. Attempts to deactivate an already inactive user or activate an already active user now return clear error messages.
- Updated the GET endpoint to support filtering users by active/inactive status via an `include_inactive` query parameter.

**Other Improvements:**
- Cleaned up and clarified some code comments and logic for user creation, ensuring default states and password hashing remain intact.